### PR TITLE
Convert bgs to mmol if needed. (#9)

### DIFF
--- a/scripts/status.js
+++ b/scripts/status.js
@@ -9,12 +9,44 @@ var fs = require('fs');
 var font = require('oled-font-5x7');
 var i2cBus = i2c.openSync(1);
 
+// Rounds value to 'digits' decimal places
+function round(value, digits)
+{
+  if (! digits) { digits = 0; }
+  var scale = Math.pow(10, digits);
+  return Math.round(value * scale) / scale;
+}
+
+function convert_bg(value, profile)
+{
+  if (profile != null && profile.out_units == "mmol/L")
+  {
+    return round(value / 18, 1).toFixed(1);
+  }
+  else
+  {
+    return Math.round(value);
+  }
+}
+
+function stripLeadingZero(value)
+{
+  var re = /^(-)?0+(?=[\.\d])/;
+  return value.toString().replace( re, '$1');
+}
+
 // setup the display
 var displayConfig = require('/root/src/openaps-menu/config/display.json');
 displayConfig.i2cBus = i2cBus;
 var display = require('/root/src/openaps-menu/lib/display/ssd1306')(displayConfig);
 
 //Parse all the .json files we need
+try {
+    var profile = JSON.parse(fs.readFileSync("/root/myopenaps/settings/profile.json"));
+} catch (e) {
+    // Note: profile.json is optional as it's only needed for mmol conversion for now. Print an error, but not return
+    console.error("Could not parse profile.json: ", e);
+}
 try {
     var suggested = JSON.parse(fs.readFileSync("/root/myopenaps/enact/suggested.json"));
 } catch (e) {
@@ -121,9 +153,9 @@ if (bg[0].delta) {
 //display BG number, add plus sign if delta is positive
 display.oled.setCursor(0,57);
 if (delta >= 0) {
-    display.oled.writeString(font, 1, "BG: "+bg[0].glucose+"+"+delta+" "+minutes+"m", 1, true);
+    display.oled.writeString(font, 1, "BG:"+convert_bg(bg[0].glucose, profile)+"+"+stripLeadingZero(convert_bg(delta, profile))+" "+minutes+"m", 1, true);
 } else {
-    display.oled.writeString(font, 1, "BG: "+bg[0].glucose+""+delta+" "+minutes+"m", 1, true);
+    display.oled.writeString(font, 1, "BG:"+convert_bg(bg[0].glucose, profile)+""+stripLeadingZero(convert_bg(delta, profile))+" "+minutes+"m", 1, true);
 }
 
 //calculate timeago for status


### PR DESCRIPTION
* Convert bgs to mmol if needed.

Had to remove an extra space otherwise the script was too long sometimes

* Follow existing style.

Get the input files from the myopenaps directory,
instead of taking them as parameters.