### PR TITLE
Fake values to prevent NightScout crash

### DIFF
--- a/scripts/getvoltage.sh
+++ b/scripts/getvoltage.sh
@@ -3,5 +3,6 @@
 command -v socat >/dev/null 2>&1 || { echo >&2 "I require socat but it's not installed. Aborting."; exit 1; }
 
 RESPONSE=`echo '{"command":"read_voltage"}' | socat -,ignoreeof ~/src/openaps-menu/socket-server.sock | sed -n 's/.*"response":\([^}]*\)}/\1/p'`
-[[ $RESPONSE = *[![:space:]]* ]] && echo $RESPONSE
+[[ $RESPONSE = *[![:space:]]* ]] && echo $RESPONSE || echo '{"batteryVoltage":3340,"battery":99}'
+# the OR at the end of the above line uploads a fake voltage (3340) and percentage (99), to work around a problem with nighscout crashing when receiving a null value
 #./getvoltage.sh | sed -n 's/.*"response":\([^}]*\)}/\1/p'


### PR DESCRIPTION
According to https://github.com/openaps/oref0/issues/1228, NightScout crashes when receiving an empty uploader battery state. This fix with fake values should help out, until we can make NightScout handle these empty values. The fake values are low and high by design, making it easy to identify them as fake values (low voltage + high percentage = improbable).