### PR TITLE
Add relevant OR part as well

### DIFF
--- a/scripts/getvoltage.sh
+++ b/scripts/getvoltage.sh
@@ -4,5 +4,6 @@ command -v socat >/dev/null 2>&1 || { echo >&2 "I require socat but it's not ins
 
 [[ $RESPONSE == "{}" ]] && unset RESPONSE
 RESPONSE=`echo '{"command":"read_voltage"}' | socat -,ignoreeof ~/src/openaps-menu/socket-server.sock | sed -n 's/.*"response":\([^}]*\)}/\1/p'`
-[[ $RESPONSE = *[![:space:]]* ]] && echo $RESPONSE
+[[ $RESPONSE = *[![:space:]]* ]] && echo $RESPONSE || echo '{"batteryVoltage":3340,"battery":99}'
+# the OR at the end of the above line uploads a fake voltage (3340) and percentage (99), to work around a problem with nighscout crashing when receiving a null value
 #./getvoltage.sh | sed -n 's/.*"response":\([^}]*\)}/\1/p'


### PR DESCRIPTION
The relevant "OR echo '{"batteryVoltage":3340,"battery":99}'" is still missing. So the script still crashes NightScout in its current state. 
Now added that line and the explaining line of comment as well. Tested for several days on Pi & RadioFruit Bonnet combo with two different NS instances.